### PR TITLE
EVA-Discover: allow binding to local if address.

### DIFF
--- a/eva_tools/EVA-Discover.ps1
+++ b/eva_tools/EVA-Discover.ps1
@@ -24,7 +24,8 @@ Param([Parameter(Mandatory = $False, Position = 0, HelpMessage = 'the number of 
       [Parameter(Mandatory = $False, Position = 1, HelpMessage = 'the IP address, which the device should use (defaults to 192.168.178.1)')][string]$requested_address,
       [Parameter(Mandatory = $False, Position = 2, HelpMessage = 'do not hold up the device in the bootloader')][bool]$nohold = $False,
       [Parameter(Mandatory = $False, Position = 3, HelpMessage = 'the broadcast address to use')][String]$bc_address = "255.255.255.255",
-      [Parameter(Mandatory = $False, Position = 4, HelpMessage = 'the port number to use')][int]$discovery_port = 5035
+      [Parameter(Mandatory = $False, Position = 4, HelpMessage = 'the port number to use')][int]$discovery_port = 5035,
+      [Parameter(Mandatory = $False, Position = 5, HelpMessage = 'the interface address to send broadcasts from')][String]$if_address = ""
 )
       
 if ($PSBoundParameters["Debug"] -and $DebugPreference -eq "Inquire") { $DebugPreference = "Continue" }      
@@ -55,6 +56,10 @@ try {
     $sender = New-Object System.Net.Sockets.UdpClient
     $sender.EnableBroadcast = $True
     $sender.ExclusiveAddressUse = $False
+    if ($if_address.Length -ne 0) {
+        $local_ep = New-Object System.Net.IPEndPoint([System.Net.IPAddress]::Parse($if_address), 0)
+        $sender.Client.Bind($local_ep)
+    }
     $sender_ready = $True
 }
 catch {


### PR DESCRIPTION
Depending on the Windows network setup, it might be necessary to bind
the UDP broadcast sender socket to an interface. By default, the limited
broadcast (255.255.255.255) will be sent on the interface with the
lowest metric route for this address.

Binding to the interface is done by (optionally) binding to the local IP
address given as `-if_address'.

Using a directed broadcast (`-bc_address') did not help in my case. Even though it was sent on the intended subnet, the box's ADAM2 obviously ignored it.